### PR TITLE
feat: migrated to algod v2 and indexer v2, added docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+build
+db-data

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ yarn-error.log*
 
 # node global constants
 /service/global.js
+
+/db-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# pull official base image
+FROM node:14.4.0-alpine
+
+# set working directory
+WORKDIR /app
+
+# add `/app/node_modules/.bin` to $PATH
+ENV PATH /app/node_modules/.bin:$PATH
+
+# install app dependencies
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install --silent && npm install pm2 -g
+
+# add app
+COPY . ./
+RUN npm run build --silent
+
+# start app
+EXPOSE 8000
+CMD ["pm2-runtime", "process.yml"]

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ AlgoSearch enables you to explore and search the [Algorand blockchain](https://w
 
 Work on AlgoSearch is funded by the [Algorand Foundation](https://algorand.foundation) through a grant to [Anish Agnihotri](https://github.com/anish-agnihotri). The scope of work includes the development of an open-source block explorer (AlgoSearch) and a WIP analytics platform.
 
+# The Fastest Approach
+
+The fastest approach to set everything up for development is using the `Sandbox` and `docker-compose`. To do that, just setup the Sandbox and do the following:
+
+```
+# Start the services
+bash docker-run.sh
+```
+
 # Run locally
 
 ## Linux / OSX
 The [go-algorand](https://github.com/algorand/go-algorand) node currently aims to support only Linux and OSX environments for development.
-
-## Disclaimer
-Simpler installation instructions, a hands-on guide, and a one-click deploy Docker image will be published upon final completion of AlgoSearch.
 
 ## Step 1: Environment setup
 
@@ -155,18 +161,6 @@ bash docker-run.sh
 ```
 
 This script will find the IPs of `localhost` and to be accessed through `dockerhost`. In other words, in your `src/global.js`, use `dockerhost` instead of `localhost`.
-
-# The Fastest Approach
-
-The fastest approach to set everything up for development is using the Sandbox and docker-compose. To do that, just setup the Sandbox and do the following:
-
-```
-# Create the folder for CouchDB
-mkdir db-data
-
-# Start the services
-bash docker-run.sh
-```
 
 # Documentation
 The [Wiki](https://github.com/Anish-Agnihotri/algosearch/wiki) is currently under construction.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ AlgoSearch enables you to explore and search the [Algorand blockchain](https://w
 **Dependencies**
 * [Node.js](https://nodejs.org/en/) 8+ for use with server and front-end.
 * [go-algorand](https://github.com/algorand/go-algorand) for Algorand `goal` node (must support archival indexing).
+* [Algorand Indexer](https://github.com/algorand/indexer) for reading committed blocks from the Algorand blockchain and maintains a database of transactions and accounts that are searchable and indexed.
 * [CouchDB](https://couchdb.apache.org/) as database solution.
 
 Work on AlgoSearch is funded by the [Algorand Foundation](https://algorand.foundation) through a grant to [Anish Agnihotri](https://github.com/anish-agnihotri). The scope of work includes the development of an open-source block explorer (AlgoSearch) and a WIP analytics platform.
@@ -22,57 +23,150 @@ The [go-algorand](https://github.com/algorand/go-algorand) node currently aims t
 ## Disclaimer
 Simpler installation instructions, a hands-on guide, and a one-click deploy Docker image will be published upon final completion of AlgoSearch.
 
-## Environment setup
-First you'll need to install [CouchDB](https://docs.couchdb.org/en/stable/install/index.html) and [Algorand's Node](https://developer.algorand.org/docs/run-a-node/setup/install/) locally.
+## Step 1: Environment setup
 
-You can run CouchDB using Docker easily:
-```
+This section explains how to set up everything locally.
+
+### The Native Approach
+
+#### Algorand's Node
+
+First you'll need to install [Algorand's Node](https://developer.algorand.org/docs/run-a-node/setup/install/) locally. Follow the instructions through the hyperlink.
+
+Make sure node is running on the preferred network and that algod details are correct in `service/global.js`.
+
+#### Indexer
+
+Then you'll need to install the [Indexer](https://developer.algorand.org/docs/run-a-node/setup/indexer/) locally. Follow the instructions through the hyperlink.
+
+#### CouchDB
+
+Finally you'll need to install [CouchDB](https://docs.couchdb.org/en/stable/install/index.html) locally.
+
+You can also run CouchDB using Docker easily:
+
+```sh
+# Create a folder called db-data
 mkdir db-data
 
 docker run -e COUCHDB_USER=admin -e COUCHDB_PASSWORD=password -p 5984:5984 --name my-couchdb -v $(pwd)/db-data:/opt/couchdb/data -d couchdb
 ```
-### AlgoSearch setup
-**install**
+
+If you are using docker compose to start the services, you can skip this step.
+
+### The Sandbox Approach
+
+You can also set up **Algorand's Node** and the **Indexer** using [Algorand's Sandbox](https://github.com/algorand/sandbox). Follow the instructions through the hyperlink.
+
+Note that you will still have to set up CouchDB if you are not using the `docker-compose.yml` offered here. 
+
+## Step 2: Configuration
+
+1. Enter your site name in `src/constants.js`.
+    - it's set to be `http://localhost:8000` as default, but if you are changing the port, remember to update `PORT` in `server.js` and `server.local.js`
+2. Enter the API endpoint of the Algorand's Node in `src/constants.js`.
+3. Copy `service/global.sample.js` to `service/global.js` and enter your node and DB details.
+    - If you are using the Sandbox approach, copy `service/global.sandbox.js` instead and update the CouchDB details if needed.
+
+## Step 3: Running AlgoSearch
+
+### The Native Approach
+
+#### Install the dependencies
+
 ```
 # Run in folder root directory
 npm install
 ```
 
-**configure**
-1. Enter your sitename in `src/constants.js`.
-2. Copy `service/global.sample.js` to `service/global.js` and enter your node and DB details.
+#### Build the code
 
-**build**
 ```
 # Run in folder root directory
 npm run build
 ```
 
-### CouchDB Setup
-1. Make sure DB is running and that DB details are correct in `service/global.js`.
-2. Create tables:
-   ```
-   node service/sync/initSync.js
-   ```
-3. Create blocks DB view:
-   1. Go to: http://127.0.0.1:5984/_utils/#/database/blocks/new_view
-   2. Fill according to [service/design.md](service/design.md)
-4. Create transactions DB view:
-   1. Go to: http://127.0.0.1:5984/_utils/#/database/transactions/new_view
-   2. Fill according to [service/design.md](service/design.md)
-5. Sync tables:
-   ```
-   node service/sync/syncAll.js
-   ```
-   Note that this step takes time to sync and should stay running as long as the server is running.
+#### Run it
 
-### Run server
+Make sure the configurations in your `src/global.js` is correct, then you'll have to do three things.
+
+One, execute the following to create tables in CouchDB:
+
+```sh
+node service/sync/initSync.js
 ```
+
+Second, execute the following to start syncing the tables:
+
+```sh
+node service/sync/syncAll.js
+```
+
+Note that this step takes time to sync and should stay running as long as the server is running.
+
+Finally, start the server:
+
+```sh
 nodemon server.js
 ```
 
-### Algorand's Node Setup
-Make sure node is running on the preferred network and that algod details are correct in `service/global.js`.
+### Docker Approach
+
+You can skip the native approach entirely and simply start the application using Docker (remember to make sure your `src/global.js` is having the correct details):
+
+```sh
+# Build the image
+docker build -t algosearch .
+
+# Run the container
+docker run algosearch
+```
+
+If you are using Linux and your container needs to access the host machine, for instance, the CouchDB you set up on your machine, run the following the start the container:
+
+```
+docker run --network="host" algosearch
+```
+
+#### Docker Compose Approach
+
+To start the server using `docker-compose`, you only need the Node and Indexer, and use DB details in `src/global.sandbox.js`, that is, make sure
+
+```
+dbhost = 'couchdb.server:5984', // Database URL
+dbuser = 'admin', // Database user
+dbpass = 'password', // Database password
+```
+
+Then start the services:
+
+```sh
+# Create the folder for CouchDB
+mkdir db-data
+
+# Start the services
+docker-compose up
+```
+
+If your Node and Indexer are on the host machine, your containers will have to access `localhost`, instead of using `docker-compose up`, run the startup script instead:
+
+```sh
+bash docker-run.sh
+```
+
+This script will find the IPs of `localhost` and to be accessed through `dockerhost`. In other words, in your `src/global.js`, use `dockerhost` instead of `localhost`.
+
+# The Fastest Approach
+
+The fastest approach to set everything up for development is using the Sandbox and docker-compose. To do that, just setup the Sandbox and do the following:
+
+```
+# Create the folder for CouchDB
+mkdir db-data
+
+# Start the services
+bash docker-run.sh
+```
 
 # Documentation
 The [Wiki](https://github.com/Anish-Agnihotri/algosearch/wiki) is currently under construction.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  algosearch:
+    image: "algosearch"
+    hostname: algo-search
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    extra_hosts:
+      - "dockerhost:$DOCKERHOST"
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+#    environment:
+#      DATABASE_NAME: couchdb
+    depends_on:
+      - couch
+
+  couch:
+    image: couchdb:2.3.1
+    hostname: couchdb.server
+    ports:
+      - "5984:5984"
+    volumes:
+      - ./db-data:/opt/couchdb/data
+    extra_hosts:
+      - "dockerhost:$DOCKERHOST"
+    # https://github.com/apache/couchdb-docker/issues/54
+    # command: curl -u admin:password -X PUT 127.0.0.1:5984/_users && curl -u admin:password -X PUT 127.0.0.1:5984/test
+    environment:
+      - COUCHDB_USER=admin
+      - COUCHDB_PASSWORD=password

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,4 @@
+# https://stackoverflow.com/a/38753971
+export DOCKERHOST=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
+docker-compose rm
+docker-compose up --build --force-recreate --remove-orphans

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,3 +1,4 @@
+mkdir -p db-data
 # https://stackoverflow.com/a/38753971
 export DOCKERHOST=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
 docker-compose rm

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "algosdk": "^1.9.1",
     "axios": "^0.19.2",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "run-sync": "node service/sync/initSync.js && node service/sync/syncAll.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/process.yml
+++ b/process.yml
@@ -1,0 +1,6 @@
+apps:
+  - script: ./server.js
+    name: 'algosearch'
+  - script: npm
+    args: run run-sync
+    name: 'algosearch-sync'

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ require('./service/query/detection')(app);
 require('./service/stats/stats')(app);
 
 // --> /health
-require('./servvice/health/health')(app);
+require('./service/health/health')(app);
 
 // --> Catch all for serving other requests
 app.get("*", function(req, res) {

--- a/server.js
+++ b/server.js
@@ -2,9 +2,17 @@ const express = require("express"); // Import express for simplified routing
 const path = require("path");
 const compression = require("compression");
 const cors = require("cors"); // Setup cors for cross-origin requests for all routes
+const algosdk = require("algosdk");
+const constants = require("./service/global");
 
 const app = express(); // Setup express
 const port = 8000; // Setup port 8000 for Express server
+
+const algoUrl = new URL(constants.algodurl);
+const client = new algosdk.Algodv2(
+    constants.algodapi,
+    algoUrl,
+    algoUrl.port ? algoUrl.port : 8080);
 
 app.use(cors()); // Enable cors
 app.use(compression()); // Compress requests;
@@ -17,7 +25,7 @@ app.get("/", function(req, res) {
 
 // --> /blockservice/:blocknumber
 // --> /all/blocks/:lastBlock/:limit/:full (paginated)
-require('./service/query/blocks')(app);
+require('./service/query/blocks')(app, client);
 
 // --> /transactionservice/:txid
 // --> /all/transactions/:lastTransaction/:limit/:full (paginated)

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const path = require("path");
 const compression = require("compression");
 const cors = require("cors"); // Setup cors for cross-origin requests for all routes
 
-const app = express(); // Setup express 
+const app = express(); // Setup express
 const port = 8000; // Setup port 8000 for Express server
 
 app.use(cors()); // Enable cors
@@ -32,6 +32,9 @@ require('./service/query/detection')(app);
 
 // --> /stats
 require('./service/stats/stats')(app);
+
+// --> /health
+require('./servvice/health/health')(app);
 
 // --> Catch all for serving other requests
 app.get("*", function(req, res) {

--- a/server.local.js
+++ b/server.local.js
@@ -24,6 +24,6 @@ require('./service/query/addresses')(app);
 require('./service/stats/stats')(app);
 
 // --> /health
-require('./servvice/health/health')(app);
+require('./service/health/health')(app);
 
 app.listen(port); // Initialize server

--- a/server.local.js
+++ b/server.local.js
@@ -2,7 +2,7 @@ const express = require("express"); // Import express for simplified routing
 const cors = require("cors"); // Setup cors for cross-origin requests for all routes
 const compression = require("compression");
 
-const app = express(); // Setup express 
+const app = express(); // Setup express
 const port = 8000; // Setup port 8000 for Express server
 
 app.use(cors()); // Enable cors
@@ -22,5 +22,8 @@ require('./service/query/addresses')(app);
 
 // --> /stats
 require('./service/stats/stats')(app);
+
+// --> /health
+require('./servvice/health/health')(app);
 
 app.listen(port); // Initialize server

--- a/service/global.sandbox.js
+++ b/service/global.sandbox.js
@@ -1,0 +1,13 @@
+// Global exports
+module.exports = Object.freeze({
+    // Supply your own CouchDB configs
+    // No need to change the following if you are using the default docker-compose.yml
+    dbhost: 'couchdb.server:5984', // Database URL
+    dbuser: 'admin', // Database user
+    dbpass: 'password', // Database password
+    // No need to change the following
+    algodurl: 'http://dockerhost:4001', // Algod node endpoint
+    algodapi: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', // Algod node API access header
+    algoIndexerUrl: 'http://dockerhost:8980', // Algo Indexer endpoint
+    algoIndexerToken: '',
+});

--- a/service/health/health.js
+++ b/service/health/health.js
@@ -1,0 +1,29 @@
+/*
+    Query: health.js
+	____________
+	Health endpoint
+	____________
+	Various Return schemas
+ */
+
+// Export express routes
+module.exports = function(app) {
+
+    // Health Check
+    app.get('/health', function(req, res) {
+        // optionslz; sff further things to check (e.g. connecting to database)
+        const healthcheck = {
+            uptime: process.uptime(),
+            message: 'OK',
+            timestamp: Date.now(),
+        };
+
+        try {
+            res.send(healthcheck);
+        } catch (e) {
+            healthcheck.message = e;
+            res.status(503).send();
+            console.log("Exception when doing health check: " + e);
+        }
+    });
+}

--- a/service/query/addresses.js
+++ b/service/query/addresses.js
@@ -32,7 +32,9 @@ module.exports = function(app) {
 				let rounds = [];
 
 				for (let i = 0; i < resp.data.transactions.length; i++) {
-					rounds.push(resp.data.transactions[i]['confirmed-round']);
+					if (resp.data.transactions[i]['confirmed-round']) {
+						rounds.push(resp.data.transactions[i]['confirmed-round']);
+					}
 				}
 
 				let uniqueRounds = [...new Set(rounds)];

--- a/service/query/addresses.js
+++ b/service/query/addresses.js
@@ -19,30 +19,30 @@ module.exports = function(app) {
 		// Request basic account information
 		axios({
 			method: 'get',
-			url: `${constants.algodurl}/account/${address}`, // Request transaction details endpoint
+			url: `${constants.algodurl}/v2/accounts/${address}`, // Request transaction details endpoint
 			headers: {'X-Algo-API-Token': constants.algodapi}
 		}).then(response => {
 			let result = response.data; // Set data to result
 
 			axios({
 				method: 'get',
-				url: `${constants.algodurl}/account/${address}/transactions?max=25`,
-				headers: {'X-Algo-API-Token': constants.algodapi}
+				url: `${constants.algoIndexerUrl}/v2/accounts/${address}/transactions?limit=25`,
+				headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 			}).then(async resp => {
 				let rounds = [];
 
 				for (let i = 0; i < resp.data.transactions.length; i++) {
-					rounds.push(resp.data.transactions[i].round);
+					rounds.push(resp.data.transactions[i]['confirmed-round']);
 				}
 
 				let uniqueRounds = [...new Set(rounds)];
 				let roundsWithTimestamp = [];
-				
+
 				for (let i = 0; i < uniqueRounds.length; i++) {
 					await axios({
 						method: 'get',
-						url: `${constants.algodurl}/block/${uniqueRounds[i]}`,
-						headers: {'X-Algo-API-Token': constants.algodapi} 
+						url: `${constants.algoIndexerUrl}/v2/blocks/${uniqueRounds[i]}`,
+						headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 					}).then(blockresponse => {
 						roundsWithTimestamp.push({"round": blockresponse.data.round, "timestamp": blockresponse.data.timestamp});
 					}).catch(error => {
@@ -52,7 +52,7 @@ module.exports = function(app) {
 				}
 
 				for (let i = 0; i < resp.data.transactions.length; i++) {
-					let round = resp.data.transactions[i].round;
+					let round = resp.data.transactions[i]['confirmed-round'];
 					for (let j = 0; j < roundsWithTimestamp.length; j++) {
 						if (roundsWithTimestamp[j].round === round) {
 							resp.data.transactions[i].timestamp = roundsWithTimestamp[j].timestamp;

--- a/service/query/blocks.js
+++ b/service/query/blocks.js
@@ -31,11 +31,11 @@ module.exports = function(app, client) {
 		}).then(async (response) => {
 			const blk = await client.block(round).do();
 			const proposer = algosdk.encodeAddress(blk["cert"]["prop"]["oprop"]);
-			const hashId = algosdk.encodeAddress(blk["cert"]["prop"]["dig"]);
+			const blockHash = Buffer.from(blk["cert"]["prop"]["dig"]).toString("base64");
 			res.send({
 				...response.data,
 				proposer,
-                hashId,
+                blockHash,
 			});
 		}).catch(error => {
 			res.status(501);
@@ -71,13 +71,13 @@ module.exports = function(app, client) {
 			for (let i = body.rows.length - 1; i >= 0; i--) {
 				const blk = await client.block(body.rows[i].doc.round).do();
 				const proposer = algosdk.encodeAddress(blk["cert"]["prop"]["oprop"]);
-				const hashId = algosdk.encodeAddress(blk["cert"]["prop"]["dig"]);
+				const blockHash = Buffer.from(blk["cert"]["prop"]["dig"]).toString("base64");
 				if (showFull) {
 					// If showFull = 1, send all data
 					blocks.push({
 						...body.rows[i],
 						proposer,
-						hashId,
+						blockHash,
 					});
 				} else {
 					// If showFull = 0, send truncated data

--- a/service/query/blocks.js
+++ b/service/query/blocks.js
@@ -7,7 +7,7 @@
 
 	Sample all/blocks:
 	{ hash, previousBlockHash, seed, proposer, round, period, txnRoot, reward, rate, frac,
-	txns, timestamp, currentProtocol, nextProtocol, nextProtocolApprovals, nextProtocolSwitchOn, 
+	txns, timestamp, currentProtocol, nextProtocol, nextProtocolApprovals, nextProtocolSwitchOn,
 	upgradePropose, upgradeApprove }
 */
 
@@ -25,8 +25,8 @@ module.exports = function(app) {
 		// Query blocks database, skipping everything till round number, and limiting to 1 response
 		axios({
 			method: 'get',
-			url: `${constants.algodurl}/block/${round}`, // Request transaction details endpoint
-			headers: {'X-Algo-API-Token': constants.algodapi}
+			url: `${constants.algoIndexerUrl}/v2/blocks/${round}`, // Request transaction details endpoint
+			headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 		}).then(response => {
 			res.send(response.data);
 		}).catch(error => {
@@ -59,7 +59,7 @@ module.exports = function(app) {
 		// Query blocks database, skipping all till lastBlock - limit, and limiting to limit
 		nano.db.use('blocks').view('latest', 'latest', {include_docs: true, descending: true, skip: lastBlock - limit, limit: limit}).then(body => {
 			let blocks = [];
-			
+
 			for (let i = body.rows.length - 1; i >= 0; i--) {
 				if (showFull) {
 					// If showFull = 1, send all data
@@ -68,8 +68,9 @@ module.exports = function(app) {
 					// If showFull = 0, send truncated data
 					blocks.push({
 						"round": body.rows[i].doc.round,
-						"transactions": Object.keys(body.rows[i].doc.txns).length,
-						"proposer": body.rows[i].doc.proposer,
+						"transactions": Object.keys(body.rows[i].doc.transactions).length,
+                        // TODO: handle this
+						// "proposer": body.rows[i].doc.proposer,
 						"timestamp": body.rows[i].doc.timestamp,
 						"reward": parseInt(body.rows[i].doc.reward) / 1000000,
 					});

--- a/service/query/blocks.js
+++ b/service/query/blocks.js
@@ -31,9 +31,11 @@ module.exports = function(app, client) {
 		}).then(async (response) => {
 			const blk = await client.block(round).do();
 			const proposer = algosdk.encodeAddress(blk["cert"]["prop"]["oprop"]);
+			const hashId = algosdk.encodeAddress(blk["cert"]["prop"]["dig"]);
 			res.send({
 				...response.data,
 				proposer,
+                hashId,
 			});
 		}).catch(error => {
 			res.status(501);
@@ -69,11 +71,13 @@ module.exports = function(app, client) {
 			for (let i = body.rows.length - 1; i >= 0; i--) {
 				const blk = await client.block(body.rows[i].doc.round).do();
 				const proposer = algosdk.encodeAddress(blk["cert"]["prop"]["oprop"]);
+				const hashId = algosdk.encodeAddress(blk["cert"]["prop"]["dig"]);
 				if (showFull) {
 					// If showFull = 1, send all data
 					blocks.push({
 						...body.rows[i],
 						proposer,
+						hashId,
 					});
 				} else {
 					// If showFull = 0, send truncated data

--- a/service/query/detection.js
+++ b/service/query/detection.js
@@ -8,7 +8,7 @@ module.exports = function(app) {
 
 		axios({
 			method: 'get',
-			url: `${constants.algodurl}/account/${string}`,
+			url: `${constants.algodurl}/v2/accounts/${string}`,
 			headers: {'X-Algo-API-Token': constants.algodapi}
 		}).then(addrresp => {
 			if (addrresp.data.address === string) {
@@ -20,8 +20,8 @@ module.exports = function(app) {
 		}).catch(() => {
 			axios({
 				method: 'get',
-				url: `${constants.algodurl}/block/${string}`,
-				headers: {'X-Algo-API-Token': constants.algodapi}
+				url: `${constants.algoIndexerUrl}/v2/blocks/${string}`,
+				headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 			}).then(blockresp => {
 				if (blockresp.data.round.toString() === string) {
 					res.send('block');
@@ -32,8 +32,8 @@ module.exports = function(app) {
 			}).catch(() => {
 				axios({
 					method: 'get',
-					url: `${constants.algodurl}/transaction/${string}`,
-					headers: {'X-Algo-API-Token': constants.algodapi}
+					url: `${constants.algoIndexerUrl}/v2/transactions/${string}`,
+					headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 				}).then(transresp => {
 					if (transresp.data.tx === string) {
 						res.send('transaction');

--- a/service/query/detection.js
+++ b/service/query/detection.js
@@ -17,7 +17,7 @@ module.exports = function(app) {
 				res.send('error');
 				console.log("Exception: false address formatting");
 			}
-		}).catch(() => {
+		}).catch((e) => {
 			axios({
 				method: 'get',
 				url: `${constants.algoIndexerUrl}/v2/blocks/${string}`,
@@ -35,7 +35,7 @@ module.exports = function(app) {
 					url: `${constants.algoIndexerUrl}/v2/transactions/${string}`,
 					headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 				}).then(transresp => {
-					if (transresp.data.tx === string) {
+					if (transresp.data.transaction && transresp.data.transaction.id === string) {
 						res.send('transaction');
 					} else {
 						res.send('error');

--- a/service/query/transactions.js
+++ b/service/query/transactions.js
@@ -89,8 +89,12 @@ module.exports = function(app) {
 							"type": body.rows[i].doc['tx-type'],
 							"tx": body.rows[i].doc.id,
 							"from": body.rows[i].doc.sender,
-							"to": body.rows[i].doc['payment-transaction'].receiver,
-							"amount": parseInt(body.rows[i].doc['payment-transaction'].amount)/1000000,
+							"to": body.rows[i].doc['payment-transaction']
+								? body.rows[i].doc['payment-transaction'].receiver
+								: undefined,
+							"amount": body.rows[i].doc['payment-transaction']
+								? parseInt(body.rows[i].doc['payment-transaction'].amount)/1000000
+								: undefined,
 							"fee": parseInt(body.rows[i].doc.fee)/1000000,
 						});
 					}

--- a/service/query/transactions.js
+++ b/service/query/transactions.js
@@ -19,15 +19,15 @@ module.exports = function(app) {
 
 		axios({
 			method: 'get',
-			url: `${constants.algodurl}/transaction/${txid}`, // Request transaction details endpoint
-			headers: {'X-Algo-API-Token': constants.algodapi}
+			url: `${constants.algoIndexerUrl}/v2/transactions/${txid}`, // Request transaction details endpoint
+			headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 		}).then(response => {
 			let result = response.data; // Store response in result
 
 			axios({
 				method: 'get',
-				url: `${constants.algodurl}/block/${result.round}`,
-				headers: {'X-Algo-API-Token': constants.algodapi}
+				url: `${constants.algoIndexerUrl}/v2/blocks/${result['current-round']}`,
+				headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 			}).then(resp => {
 				result.timestamp = resp.data.timestamp; // Add timestamp to result JSON
 				res.send(result);
@@ -47,8 +47,8 @@ module.exports = function(app) {
 
 		axios({
 			method: 'get',
-			url: `${constants.algodurl}/account/${address}/transactions?max=100000000`, // Set arbitrary unlimited max (0 doesn't work)
-			headers: {'X-Algo-API-Token': constants.algodapi}
+			url: `${constants.algoIndexerUrl}/v2/accounts/${address}/transactions?limit=100000000`, // Set arbitrary unlimited max (0 doesn't work)
+			headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 		}).then(response => {
 			res.send(response.data.transactions); // Return transaction data as response
 		}).catch(error => {
@@ -85,12 +85,12 @@ module.exports = function(app) {
 					} else {
 						// If showFull = 0, return truncated data (for tables and low bandwidth usage)
 						transaction.push({
-							"round": body.rows[i].doc.round,
-							"type": body.rows[i].doc.type,
-							"tx": body.rows[i].doc.tx,
-							"from": body.rows[i].doc.from,
-							"to": body.rows[i].doc.payment.to,
-							"amount": parseInt(body.rows[i].doc.payment.amount)/1000000,
+							"round": body.rows[i].doc['confirmed-round'],
+							"type": body.rows[i].doc['tx-type'],
+							"tx": body.rows[i].doc.id,
+							"from": body.rows[i].doc.sender,
+							"to": body.rows[i].doc['payment-transaction'].receiver,
+							"amount": parseInt(body.rows[i].doc['payment-transaction'].amount)/1000000,
 							"fee": parseInt(body.rows[i].doc.fee)/1000000,
 						});
 					}

--- a/service/stats/stats.js
+++ b/service/stats/stats.js
@@ -68,7 +68,8 @@ module.exports = function(app) {
 						"round": body.rows[i].doc.round,
 						"proposer": body.rows[i].doc.proposer,
 						"numtxn": Object.keys(body.rows[i].doc.transactions).length,
-						"timestamp": body.rows[i].doc.timestamp
+						"timestamp": body.rows[i].doc.timestamp,
+						"genesis-id": body.rows[i].doc['genesis-id'],
 					});
 				}
 

--- a/service/stats/stats.js
+++ b/service/stats/stats.js
@@ -57,7 +57,7 @@ module.exports = function(app) {
 	app.get('/latest', function(req, res) {
 		axios({
 			method: 'get',
-			url: `${constants.algodurl}/ledger/supply`, // Request ledger supply endpoint
+			url: `${constants.algodurl}/v2/ledger/supply`, // Request ledger supply endpoint
 			headers: {'X-Algo-API-Token': constants.algodapi}
 		}).then(lbody => {
 			// Get last 10 transactions
@@ -67,7 +67,7 @@ module.exports = function(app) {
 					blocks.push({
 						"round": body.rows[i].doc.round,
 						"proposer": body.rows[i].doc.proposer,
-						"numtxn": Object.keys(body.rows[i].doc.txns).length,
+						"numtxn": Object.keys(body.rows[i].doc.transactions).length,
 						"timestamp": body.rows[i].doc.timestamp
 					});
 				}

--- a/service/sync/initSync.js
+++ b/service/sync/initSync.js
@@ -54,7 +54,7 @@ const initTransactionsDB = () => {
 const initAddressesDB = () => {
 	console.log("Checking for addresses database");
 
-	nano.db.list().then(body => {
+	return nano.db.list().then(body => {
 		if (!body.includes('addresses')) {
 			console.log("addresses database does not exist, creating...");
 			nano.db.create('addresses');
@@ -112,10 +112,14 @@ const insertQueryView = () => {
 	});
 }
 
-// Executing this file will also run the functions:
-initBlocksDB();
-initTransactionsDB();
-initAddressesDB();
+async function init() {
+	// Executing this file will also run the functions:
+	await initBlocksDB();
+	await initTransactionsDB();
+	await initAddressesDB();
+}
+
+init();
 
 // Export functions
 module.exports = {

--- a/service/sync/syncAll.js
+++ b/service/sync/syncAll.js
@@ -138,10 +138,11 @@ async function bulkAddBlocks(blockNum, currentNum) {
 				headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 			});
 
-			const proposer = await getProposer(client, blockNum + increment + 1);
+			const { proposer, hashId }= await getProposerAndHashId(client, blockNum + increment + 1);
 			blocksArray.push({
 				...response.data,
 				proposer,
+				hashId,
 			}); // Push block to array
 
 			let timestamp = response.data.timestamp; // Collect timestamp from block
@@ -238,10 +239,11 @@ async function addBlock(blockNum, currentNum) {
 			headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
 		});
 
-		const proposer = await getProposer(client, blockNum);
+		const { proposer, hashId } = await getProposerAndHashId(client, blockNum);
 		blocks.insert({
 			...response.data,
 			proposer,
+			hashId,
 		}); // Insert block data to blocks database as doc
 		let timestamp = response.data.timestamp; // Collect timestamp from block
 
@@ -285,15 +287,16 @@ async function addBlock(blockNum, currentNum) {
 		console.log(`Block added: ${blockNum} of ${currentNum}`); // Log block addition
 
 	} catch (e) {
-		console.log("Exception when adding block to blocks database: " + error);
+		console.log("Exception when adding block to blocks database: " + e);
 	}
 }
 
-async function getProposer(client, blockNum) {
+async function getProposerAndHashId(client, blockNum) {
 	try {
 		const blk = await client.block(blockNum).do();
 		const proposer = algosdk.encodeAddress(blk["cert"]["prop"]["oprop"]);
-		return proposer;
+		const hashId = algosdk.encodeAddress(blk["cert"]["prop"]["dig"]);
+		return { proposer, hashId };
 	} catch (e) {
 		console.log("Error getting proposer: " + e);
 	}

--- a/service/sync/syncAll.js
+++ b/service/sync/syncAll.js
@@ -131,11 +131,13 @@ async function bulkAddBlocks(blockNum, currentNum) {
 	let increment = 0; // for async loop functionality
 
 	while (increment < 250) {
-		await axios({
-			method: 'get',
-			url: `${constants.algoIndexerUrl}/v2/blocks/${blockNum + increment + 1}`, // Retrieve each block in succession
-			headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
-		}).then(async response => {
+		try {
+			const response = await axios({
+				method: 'get',
+				url: `${constants.algoIndexerUrl}/v2/blocks/${blockNum + increment + 1}`, // Retrieve each block in succession
+				headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
+			});
+
 			const proposer = await getProposer(client, blockNum + increment + 1);
 			blocksArray.push({
 				...response.data,
@@ -201,9 +203,9 @@ async function bulkAddBlocks(blockNum, currentNum) {
 					}
 				}
 			}
-		}).catch(error => {
+		} catch (error) {
 			console.log("Exception when bulk adding blocks: " + error);
-		});
+		}
 
 		increment++; // Increment for async loop functionality
 	}
@@ -229,12 +231,14 @@ async function bulkAddBlocks(blockNum, currentNum) {
 	Add block data to CouchDB (non-bulk, singular)
 */
 async function addBlock(blockNum, currentNum) {
-	await axios({
-		method: 'get',
-		url: `${constants.algoIndexerUrl}/v2/blocks/${blockNum}`, // Get block information from algod
-		headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
-	}).then(async response => {
-	    const proposer = await getProposer(client, blockNum);
+	try {
+		const response = await axios({
+			method: 'get',
+			url: `${constants.algoIndexerUrl}/v2/blocks/${blockNum}`, // Get block information from algod
+			headers: {'X-Indexer-API-Token': constants.algoIndexerToken}
+		});
+
+		const proposer = await getProposer(client, blockNum);
 		blocks.insert({
 			...response.data,
 			proposer,
@@ -279,9 +283,10 @@ async function addBlock(blockNum, currentNum) {
 			}
 		}
 		console.log(`Block added: ${blockNum} of ${currentNum}`); // Log block addition
-	}).catch(error => {
+
+	} catch (e) {
 		console.log("Exception when adding block to blocks database: " + error);
-	})
+	}
 }
 
 async function getProposer(client, blockNum) {

--- a/src/components/homeheader/index.js
+++ b/src/components/homeheader/index.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import './index.css';
 import algorand from './algorand.svg';
+import { algodurl } from '../../constants';
 
 export default class HomeHeader extends React.Component {
 	constructor() {
 		super();
 
 		this.state = {
-			synced: false
+			synced: false,
 		};
 	}
 	render() {
@@ -16,7 +17,11 @@ export default class HomeHeader extends React.Component {
 				<div className="sizer">
 					<div>
 						<h1><img src={algorand} alt="Algorand logo"/>Block Explorer</h1>
-						<span>Open-source block explorer for the Algorand mainnet. Currently <div className="home-status"><div className={`status-light ${this.props.synced ? "status-online" : "status-offline"}`}></div> {this.props.synced ? "in sync" : "out of sync"}</div> with the network.</span>
+						<span>Open-source block explorer for the Algorand mainnet. Currently
+							<div className="home-status">
+								<div className={`status-light ${this.props.synced ? "status-online" : "status-offline"}`} /> {this.props.synced ? "in sync" : "out of sync"}
+							</div> with the network {algodurl}.
+						</span>
 					</div>
 					<div>
 					</div>

--- a/src/components/homeheader/index.js
+++ b/src/components/homeheader/index.js
@@ -20,7 +20,7 @@ export default class HomeHeader extends React.Component {
 						<span>Open-source block explorer for the Algorand mainnet. Currently
 							<div className="home-status">
 								<div className={`status-light ${this.props.synced ? "status-online" : "status-offline"}`} /> {this.props.synced ? "in sync" : "out of sync"}
-							</div> with the network {algodurl}.
+							</div> with the network <a href={algodurl}>{this.props.genesisId}</a>
 						</span>
 					</div>
 					<div>

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -61,7 +61,7 @@ class Layout extends React.Component {
 					<AddressHeader data={this.props.data} />
 				) : null}
 				{this.props.homepage ? (
-					<HomeHeader synced={this.props.synced} />
+					<HomeHeader synced={this.props.synced} genesisId={this.props.genesisId} />
 				) : null}
 				<div className={`content ${this.props.homepage ? "content-shortened" : ""}`}>
 					<div className="sizer">

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,3 +5,5 @@ export function formatValue(number) {
 }
 
 export const siteName = "http://localhost:8000";
+
+export const algodurl = "http://127.0.0.1:4001";

--- a/src/pages/Address/index.js
+++ b/src/pages/Address/index.js
@@ -41,6 +41,7 @@ class Address extends React.Component {
 	}
 
 	render() {
+		console.log(this.state.data);
 		const columns = [
 			{Header: '#', accessor: 'confirmed-round', Cell: props => <span className="rownumber">{props.index + 1}</span>},
 			{Header: 'Round', accessor: 'confirmed-round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
@@ -62,7 +63,12 @@ class Address extends React.Component {
 				<div className="cardcontainer address-cards">
 					<Statscard
 						stat="Round last seen"
-						value={this.state.loading ? <Load /> : formatValue(this.state.data.confirmed_transactions[0]['confirmed-round'])}
+						value={this.state.loading
+							? <Load />
+							: (this.state.data.confirmed_transactions.length > 0
+								? formatValue(this.state.data.confirmed_transactions[0]['confirmed-round'])
+								: '-'
+							)}
 					/>
 					<Statscard
 						stat="Rewards"

--- a/src/pages/Address/index.js
+++ b/src/pages/Address/index.js
@@ -42,26 +42,27 @@ class Address extends React.Component {
 
 	render() {
 		const columns = [
-			{Header: '#', accessor: 'round', Cell: props => <span className="rownumber">{props.index + 1}</span>},
-			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'TX ID', accessor: 'tx', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'From', accessor: 'from', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>}, 
+			{Header: '#', accessor: 'confirmed-round', Cell: props => <span className="rownumber">{props.index + 1}</span>},
+			{Header: 'Round', accessor: 'confirmed-round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'TX ID', accessor: 'id', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'From', accessor: 'sender', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
 			{Header: '', accessor: 'from', Cell: props => this.state.address === props.value ? <span className="type noselect">OUT</span> : <span className="type type-width-in noselect">IN</span>},
-			{Header: 'To', accessor: 'payment.to', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
-			{Header: 'Amount', accessor: 'payment.amount', Cell: props => <span>{formatValue(props.value / 1000000)} <AlgoIcon /></span>},
+			{Header: 'To', accessor: 'payment-transaction.receiver', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'Amount', accessor: 'payment-transaction.amount', Cell: props => <span>{formatValue(props.value / 1000000)} <AlgoIcon /></span>},
 			{Header: 'Time', accessor: 'timestamp', Cell: props=> <span className="nocolor">{moment.unix(props.value).fromNow()}</span>}
 		];
 
 		return (
 			<Layout data={{
 				"address": this.state.address,
-				"balance": formatValue(this.state.data.amount / 1000000)
+				// "balance": formatValue(this.state.data.amount / 1000000)
+				"balance": formatValue(this.state.data['amount-without-pending-rewards'] / 1000000)
 			}}
 			addresspage>
 				<div className="cardcontainer address-cards">
 					<Statscard
 						stat="Round last seen"
-						value={this.state.loading ? <Load /> : formatValue(this.state.data.confirmed_transactions[0].round)}
+						value={this.state.loading ? <Load /> : formatValue(this.state.data.confirmed_transactions[0]['confirmed-round'])}
 					/>
 					<Statscard
 						stat="Rewards"
@@ -76,7 +77,7 @@ class Address extends React.Component {
 						stat="Pending rewards"
 						value={this.state.loading ? <Load /> : (
 							<div>
-								{formatValue(this.state.data.pendingrewards / 1000000)}
+								{formatValue(this.state.data['pending-rewards'] / 1000000)}
 								<AlgoIcon />
 							</div>
 						)}

--- a/src/pages/AddressTransaction/index.js
+++ b/src/pages/AddressTransaction/index.js
@@ -7,6 +7,7 @@ import ReactTable from 'react-table-6';
 import AlgoIcon from '../../components/algoicon';
 import 'react-table-6/react-table.css';
 import {formatValue, siteName} from '../../constants';
+import moment from "moment";
 
 class AddressTransaction extends React.Component {
 	constructor() {
@@ -37,14 +38,14 @@ class AddressTransaction extends React.Component {
 	render() {
 		// Table columns
 		const columns = [
-			{Header: '#', accessor: 'round', Cell: props => <span className="rownumber">{props.index + 1}</span>},
-			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'TX ID', accessor: 'tx', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'From', accessor: 'from', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: '', accessor: 'from', Cell: props => this.state.address === props.value ? <span className="type noselect">OUT</span> : <span className="type type-width-in noselect">IN</span>},
-			{Header: 'To', accessor: 'payment.to', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
-			{Header: 'Amount', accessor: 'payment.amount', Cell: props => <span>{formatValue(props.value / 1000000)} <AlgoIcon /></span>},
-			{Header: 'Time', accessor: 'round', Cell: props=> <span className="nocolor">Coming soon</span>}
+			{Header: '#', accessor: 'confirmed-round', Cell: props => <span className="rownumber">{props.index + 1}</span>},
+			{Header: 'Round', accessor: 'confirmed-round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'TX ID', accessor: 'id', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'From', accessor: 'sender', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: '', accessor: 'sender', Cell: props => this.state.address === props.value ? <span className="type noselect">OUT</span> : <span className="type type-width-in noselect">IN</span>},
+			{Header: 'To', accessor: 'payment-transaction.receiver', Cell: props => this.state.address === props.value ? <span className="nocolor">{props.value}</span> : <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'Amount', accessor: 'payment-transaction.amount', Cell: props => <span>{formatValue(props.value / 1000000)} <AlgoIcon /></span>},
+			{Header: 'Time', accessor: 'round-time', Cell: props=> <span className="nocolor">{moment.unix(props.value).fromNow()}</span>}
 		];
 
 		return (

--- a/src/pages/Block/index.js
+++ b/src/pages/Block/index.js
@@ -81,7 +81,7 @@ class Block extends React.Component {
 								</tr>
 								<tr>
 									<td>Block hash</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.hashId}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data.blockHash}</td>
 								</tr>
 								<tr>
 									<td>Previous block hash</td>

--- a/src/pages/Block/index.js
+++ b/src/pages/Block/index.js
@@ -81,7 +81,7 @@ class Block extends React.Component {
 								</tr>
 								<tr>
 									<td>Block hash</td>
-									<td>{this.state.loading ? <Load/> : this.state.data['genesis-hash']}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data.hashId}</td>
 								</tr>
 								<tr>
 									<td>Previous block hash</td>

--- a/src/pages/Block/index.js
+++ b/src/pages/Block/index.js
@@ -28,7 +28,7 @@ class Block extends React.Component {
 			type: 'get',
 			url: `${siteName}/blockservice/${blockNum}`
 		}).then(response => {
-			this.setState({data: response.data, transactions: response.data.txns.transactions, loading: false});
+			this.setState({data: response.data, transactions: response.data.transactions, loading: false});
 		}).catch(error => {
 			console.log(`Exception when retrieving block #${blockNum}: ${error}`)
 		})
@@ -43,12 +43,12 @@ class Block extends React.Component {
 
 	render() {
 		const columns = [
-			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'TX ID', accessor: 'tx', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'Type', accessor: 'type', Cell: props => <span className="type noselect">{props.value}</span>},
-			{Header: 'From', accessor: 'from', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'To', accessor: 'payment.to', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
-			{Header: 'Amount', accessor: 'payment.amount', Cell: props => <span>{formatValue(props.value/1000000)} <AlgoIcon /></span>},
+			{Header: 'Round', accessor: 'confirmed-round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'TX ID', accessor: 'id', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'Type', accessor: 'tx-type', Cell: props => <span className="type noselect">{props.value}</span>},
+			{Header: 'From', accessor: 'sender', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'To', accessor: 'payment-transaction.receiver', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'Amount', accessor: 'payment-transaction.amount', Cell: props => <span>{formatValue(props.value/1000000)} <AlgoIcon /></span>},
 			{Header: 'Fee', accessor: 'fee', Cell: props => <span>{formatValue(props.value/1000000)} <AlgoIcon /></span>}
 		];
 
@@ -81,11 +81,11 @@ class Block extends React.Component {
 								</tr>
 								<tr>
 									<td>Block hash</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.hash}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data['genesis-hash']}</td>
 								</tr>
 								<tr>
 									<td>Previous block hash</td>
-									<td>{this.state.loading ? <Load/> : (<NavLink to={`/block/${parseInt(this.state.blocknum) - 1}`}>{this.state.data.previousBlockHash}</NavLink>)}</td>
+									<td>{this.state.loading ? <Load/> : (<NavLink to={`/block/${parseInt(this.state.blocknum) - 1}`}>{this.state.data['previous-block-hash']}</NavLink>)}</td>
 								</tr>
 								<tr>
 									<td>Seed</td>
@@ -119,7 +119,7 @@ class Block extends React.Component {
 					<span>Governance Overview</span>
 					<div>
 						<table cellSpacing="0">
-							<thead>	
+							<thead>
 								<tr>
 									<th>Identifier</th>
 									<th>Value</th>
@@ -128,31 +128,35 @@ class Block extends React.Component {
 							<tbody>
 								<tr>
 									<td>Current protocol</td>
-									<td>{this.state.loading ? <Load/> : (<a href={this.state.data.currentProtocol} target="_blank" rel="noopener noreferrer">{this.state.data.currentProtocol}</a>)}</td>
+									<td>
+										{this.state.loading ? <Load/> : (<a href={this.state.data['upgrade-state']['current-protocol']} target="_blank" rel="noopener noreferrer">{this.state.data['upgrade-state']['current-protocol']}</a>)}
+									</td>
 								</tr>
 								<tr>
 									<td>Next protocol</td>
-									<td>{this.state.loading ? <Load/> : (<a href={this.state.data.nextProtocol} target="_blank" rel="noopener noreferrer">{this.state.data.nextProtocol}</a>)}</td>
+									<td>
+										{this.state.loading ? <Load/> : (<a href={this.state.data['upgrade-state']['next-protocol']} target="_blank" rel="noopener noreferrer">{this.state.data['upgrade-state']['next-protocol']}</a>)}
+									</td>
 								</tr>
 								<tr>
 									<td>Next protocol approvals</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.nextProtocolApprovals}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data['upgrade-state']['next-protocol-approvals']}</td>
 								</tr>
 								<tr>
 									<td>Next protocol vote before</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.nextProtocolVoteBefore}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data['upgrade-state']['next-protocol-vote-before']}</td>
 								</tr>
 								<tr>
 									<td>Next protocol switch on</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.nextProtocolSwitchOn}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data['upgrade-state']['next-protocol-switch-on']}</td>
 								</tr>
 								<tr>
 									<td>Upgrade proposal</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.upgradePropose}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data['upgrade-vote']['upgrade-propose']}</td>
 								</tr>
 								<tr>
 									<td>Upgrade approved</td>
-									<td>{this.state.loading ? <Load/> : this.state.data.upgradeApprove}</td>
+									<td>{this.state.loading ? <Load/> : this.state.data['upgrade-vote']['upgrade-approve']}</td>
 								</tr>
 							</tbody>
 						</table>

--- a/src/pages/Blocks/index.js
+++ b/src/pages/Blocks/index.js
@@ -85,9 +85,9 @@ class Blocks extends React.Component {
 	render() {
 		// Table columns
 		const columns = [
-			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'Transactions', accessor: 'transactions'}, 
-			{Header: 'Proposed by', accessor: 'proposer', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>}, 
+			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'Transactions', accessor: 'transactions'},
+			{Header: 'Proposed by', accessor: 'proposer', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
 			{Header: 'Time', accessor: 'timestamp', Cell: props => <span>{moment.unix(props.value).fromNow()}</span>}
 		];
 

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -27,7 +27,7 @@ class Home extends React.Component {
 			method: 'get',
 			url: `${siteName}/latest`
 		}).then(response => {
-			const synced = Math.ceil(response.data.blocks[0].round/100)*100 === Math.ceil(response.data.ledger.round/100)*100 ? true : false;
+			const synced = Math.ceil(response.data.blocks[0].round/100)*100 === Math.ceil(response.data.ledger['current_round']/100)*100 ? true : false;
 			this.setState({blocks: response.data.blocks, transactions: response.data.transactions, ledger: response.data.ledger, synced: synced, loading: false});
 		}).catch(error => {
 			console.log("Error when retrieving latest statistics: " + error);

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -54,18 +54,18 @@ class Home extends React.Component {
 
 	render() {
 		const block_columns = [
-			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>}, 
+			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
 			{Header: 'Proposer', accessor: 'proposer',  Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
-			{Header: '# TX', accessor: 'numtxn', Cell: props => <span className="nocolor">{props.value}</span>}, 
+			{Header: '# TX', accessor: 'numtxn', Cell: props => <span className="nocolor">{props.value}</span>},
 			{Header: 'Time', accessor: 'timestamp', Cell: props => <span className="nocolor">{moment.unix(props.value).fromNow()}</span>}
 		];
 		const block_columns_id = {id: "home-latest-block-sizing"};
 
 		const transaction_columns = [
-			{Header: 'TX ID', accessor: 'tx', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'From', accessor: 'from',  Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
-			{Header: 'To', accessor: 'payment.to',  Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'Amount', accessor: 'payment.amount', Cell: props => <span>{<span className="nocolor">{formatValue(props.value / 1000000)}</span>} <AlgoIcon /></span>},
+			{Header: 'TX ID', accessor: 'id', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'From', accessor: 'sender',  Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'To', accessor: 'payment-transaction.receiver',  Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'Amount', accessor: 'payment-transaction.amount', Cell: props => <span>{<span className="nocolor">{formatValue(props.value / 1000000)}</span>} <AlgoIcon /></span>},
 			{Header: 'Time', accessor: 'timestamp', Cell: props => <span className="nocolor">{moment.unix(props.value).fromNow()}</span>}
 		];
 		const transaction_columns_id = {id: "home-latest-transaction-sizing"};
@@ -76,13 +76,13 @@ class Home extends React.Component {
 				<div className="cardcontainer address-cards home-cards">
 					<Statscard
 						stat="Latest Round"
-						value={this.state.loading ? <Load /> : formatValue(this.state.ledger.round)}
+						value={this.state.loading ? <Load /> : formatValue(this.state.ledger.current_round)}
 					/>
 					<Statscard
 						stat="Online Stake"
 						value={this.state.loading ? <Load /> : (
 							<div>
-								{formatValue(this.state.ledger.onlineMoney / 1000000)}
+								{formatValue(this.state.ledger['online-money'] / 1000000)}
 								<AlgoIcon />
 							</div>
 						)}
@@ -91,7 +91,7 @@ class Home extends React.Component {
 						stat="Circulating supply"
 						value={this.state.loading ? <Load /> : (
 							<div>
-								{formatValue(this.state.ledger.totalMoney / 1000000)}
+								{formatValue(this.state.ledger['total-money'] / 1000000)}
 								<AlgoIcon />
 							</div>
 						)}

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -27,8 +27,19 @@ class Home extends React.Component {
 			method: 'get',
 			url: `${siteName}/latest`
 		}).then(response => {
-			const synced = Math.ceil(response.data.blocks[0].round/100)*100 === Math.ceil(response.data.ledger['current_round']/100)*100 ? true : false;
-			this.setState({blocks: response.data.blocks, transactions: response.data.transactions, ledger: response.data.ledger, synced: synced, loading: false});
+		    if (response.data && response.data.blocks && response.data.blocks.length > 0) {
+				const synced = Math.ceil(response.data.blocks[0].round / 100) * 100
+					=== Math.ceil(response.data.ledger['current_round'] / 100) * 100;
+				const genesisId = response.data.blocks[0]['genesis-id'];
+				this.setState({
+					blocks: response.data.blocks,
+					transactions: response.data.transactions,
+					ledger: response.data.ledger,
+					synced: synced,
+					loading: false,
+					genesisId,
+				});
+			}
 		}).catch(error => {
 			console.log("Error when retrieving latest statistics: " + error);
 		})
@@ -71,7 +82,7 @@ class Home extends React.Component {
 		const transaction_columns_id = {id: "home-latest-transaction-sizing"};
 
 		return (
-			<Layout synced={this.state.synced} homepage>
+			<Layout synced={this.state.synced} genesisId={this.state.genesisId} homepage>
 				<HomeSearch />
 				<div className="cardcontainer address-cards home-cards">
 					<Statscard

--- a/src/pages/Transaction/index.js
+++ b/src/pages/Transaction/index.js
@@ -114,18 +114,15 @@ class Transaction extends React.Component {
 										{this.state.loading ? <Load /> : (
 											<div>
 												{this.state.transaction.transaction.note && this.state.transaction.transaction.note !== '' ? (
-													// <div>
-													// 	<div>
-													// 		<span>Base 64:</span>
-													// 		<textarea defaultValue={this.state.transaction.transaction.note} readOnly></textarea>
-													// 	</div>
-													// 	<div>
-													// 		<span>Converted:</span>
-													// 		<textarea defaultValue={atob(this.state.transaction.transaction.note)} readOnly></textarea>
-													// 	</div>
-													// </div>
-                                                    <div>
-														<textarea defaultValue={this.state.transaction.transaction.note} readOnly></textarea>
+													<div>
+														<div>
+															<span>Base 64:</span>
+															<textarea defaultValue={this.state.transaction.transaction.note} readOnly></textarea>
+														</div>
+														<div>
+															<span>Converted:</span>
+															<textarea defaultValue={atob(this.state.transaction.transaction.note)} readOnly></textarea>
+														</div>
 													</div>
 												) : null}
 											</div>

--- a/src/pages/Transaction/index.js
+++ b/src/pages/Transaction/index.js
@@ -60,29 +60,29 @@ class Transaction extends React.Component {
 							<tbody>
 								<tr>
 									<td>ID</td>
-									<td>{this.state.loading ? <Load /> : this.state.txid}</td>
+									<td>{this.state.loading ? <Load /> : this.state.transaction.transaction.id}</td>
 								</tr>
 								<tr>
 									<td>Round</td>
-									<td>{this.state.loading ? <Load /> : <NavLink to={`/block/${this.state.transaction.round}`}>{this.state.transaction.round}</NavLink>}</td>
+									<td>{this.state.loading ? <Load /> : <NavLink to={`/block/${this.state.transaction.transaction['comfirmed-round']}`}>{this.state.transaction.transaction['confirmed-round']}</NavLink>}</td>
 								</tr>
 								<tr>
 									<td>Type</td>
-									<td>{this.state.loading ? <Load /> : <span className="type noselect">{this.state.transaction.type}</span>}</td>
+									<td>{this.state.loading ? <Load /> : <span className="type noselect">{this.state.transaction.transaction['tx-type']}</span>}</td>
 								</tr>
 								<tr>
 									<td>Sender</td>
-									<td>{this.state.loading ? <Load /> : <NavLink to={`/address/${this.state.transaction.from}`}>{this.state.transaction.from}</NavLink>}</td>
+									<td>{this.state.loading ? <Load /> : <NavLink to={`/address/${this.state.transaction.transaction.sender}`}>{this.state.transaction.transaction.sender}</NavLink>}</td>
 								</tr>
 								<tr>
 									<td>Receiver</td>
-									<td>{this.state.loading ? <Load /> : <NavLink to={`/address/${this.state.transaction.payment.to}`}>{this.state.transaction.payment.to}</NavLink>}</td>
+									<td>{this.state.loading ? <Load /> : <NavLink to={`/address/${this.state.transaction.transaction['payment-transaction'].receiver}`}>{this.state.transaction.transaction['payment-transaction'].receiver}</NavLink>}</td>
 								</tr>
 								<tr>
 									<td>Amount</td>
 									<td>{this.state.loading ? <Load /> : (
 										<div className="tx-hasicon">
-											{formatValue(this.state.transaction.payment.amount / 1000000)}
+											{formatValue(this.state.transaction.transaction['payment-transaction'].amount / 1000000)}
 											<AlgoIcon />
 										</div>
 									)}</td>
@@ -91,38 +91,41 @@ class Transaction extends React.Component {
 									<td>Fee</td>
 									<td>{this.state.loading ? <Load /> : (
 										<div className="tx-hasicon">
-											{formatValue(this.state.transaction.fee / 1000000)}
+											{formatValue(this.state.transaction.transaction.fee / 1000000)}
 											<AlgoIcon />
 										</div>
 									)}</td>
 								</tr>
 								<tr>
 									<td>First round</td>
-									<td>{this.state.loading ? <Load /> : <NavLink to={`/block/${this.state.transaction["first-round"]}`}>{this.state.transaction["first-round"]}</NavLink>}</td>
+									<td>{this.state.loading ? <Load /> : <NavLink to={`/block/${this.state.transaction.transaction["first-valid"]}`}>{this.state.transaction.transaction["first-valid"]}</NavLink>}</td>
 								</tr>
 								<tr>
 									<td>Last round</td>
-									<td>{this.state.loading ? <Load /> : <NavLink to={`/block/${this.state.transaction["last-round"]}`}>{this.state.transaction["last-round"]}</NavLink>}</td>
+									<td>{this.state.loading ? <Load /> : <NavLink to={`/block/${this.state.transaction.transaction["last-valid"]}`}>{this.state.transaction.transaction["last-valid"]}</NavLink>}</td>
 								</tr>
 								<tr>
 									<td>Timestamp</td>
 									<td>{this.state.loading ? <Load /> : moment.unix(this.state.transaction.timestamp).format("LLLL")}</td>
 								</tr>
 								<tr>
-									<td>Base 64</td>
+									<td>Note</td>
 									<td>
 										{this.state.loading ? <Load /> : (
 											<div>
-												{this.state.transaction.noteb64 && this.state.transaction.noteb64 !== '' ? (
-													<div>
-														<div>
-															<span>Base 64:</span>
-															<textarea defaultValue={this.state.transaction.noteb64} readOnly></textarea>
-														</div>
-														<div>
-															<span>Converted:</span>
-															<textarea defaultValue={atob(this.state.transaction.noteb64)} readOnly></textarea>
-														</div>
+												{this.state.transaction.transaction.note && this.state.transaction.transaction.note !== '' ? (
+													// <div>
+													// 	<div>
+													// 		<span>Base 64:</span>
+													// 		<textarea defaultValue={this.state.transaction.transaction.note} readOnly></textarea>
+													// 	</div>
+													// 	<div>
+													// 		<span>Converted:</span>
+													// 		<textarea defaultValue={atob(this.state.transaction.transaction.note)} readOnly></textarea>
+													// 	</div>
+													// </div>
+                                                    <div>
+														<textarea defaultValue={this.state.transaction.transaction.note} readOnly></textarea>
 													</div>
 												) : null}
 											</div>
@@ -148,7 +151,7 @@ class Transaction extends React.Component {
 									<td>From rewards</td>
 									<td>{this.state.loading ? <Load /> : (
 										<div className="tx-hasicon">
-											{formatValue(this.state.transaction.fromrewards / 1000000)}
+											{formatValue(this.state.transaction.transaction['sender-rewards'] / 1000000)}
 											<AlgoIcon />
 										</div>
 									)}</td>
@@ -157,18 +160,18 @@ class Transaction extends React.Component {
 									<td>To rewards</td>
 									<td>{this.state.loading ? <Load /> : (
 										<div className="tx-hasicon">
-											{formatValue(this.state.transaction.payment.torewards / 1000000)}
+											{formatValue(this.state.transaction.transaction['receiver-rewards'] / 1000000)}
 											<AlgoIcon />
 										</div>
 									)}</td>
 								</tr>
 								<tr>
 									<td>Genesis ID</td>
-									<td>{this.state.loading ? <Load /> : this.state.transaction.genesisID}</td>
+									<td>{this.state.loading ? <Load /> : this.state.transaction.transaction['genesis-id']}</td>
 								</tr>
 								<tr>
 									<td>Genesis hash</td>
-									<td>{this.state.loading ? <Load /> : this.state.transaction.genesishashb64}</td>
+									<td>{this.state.loading ? <Load /> : this.state.transaction.transaction['genesis-hash']}</td>
 								</tr>
 							</tbody>
 						</table>

--- a/src/pages/Transactions/index.js
+++ b/src/pages/Transactions/index.js
@@ -93,7 +93,11 @@ class Transactions extends React.Component {
 				<div className="cardcontainer">
 					<Statscard
 						stat="Transaction last seen"
-						value={this.state.loading ? <Load /> : formatValue(this.state.transactions[0].round)}
+						value={this.state.loading
+							? <Load />
+							: (this.state.transactions.length > 0
+								? formatValue(this.state.transactions[0].round)
+								: '')}
 					/>
 					<Statscard
 						stat="Transactions sent (24H)"

--- a/src/pages/Transactions/index.js
+++ b/src/pages/Transactions/index.js
@@ -23,7 +23,7 @@ class Transactions extends React.Component {
 			transactions: [] // Transactions data
 		};
 	}
-	
+
 	// Update page size
 	updatePageSize = (pageIndex, pageSize) => {
 		this.setState({
@@ -73,10 +73,10 @@ class Transactions extends React.Component {
 	render() {
 		// Table columns
 		const columns = [
-			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>}, 
-			{Header: 'TX ID', accessor: 'tx', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>}, 
+			{Header: 'Round', accessor: 'round', Cell: props => <NavLink to={`/block/${props.value}`}>{props.value}</NavLink>},
+			{Header: 'TX ID', accessor: 'tx', Cell: props => <NavLink to={`/tx/${props.value}`}>{props.value}</NavLink>},
 			{Header: 'Type', accessor: 'type', Cell: props => <span className="type noselect">{props.value}</span>},
-			{Header: 'From', accessor: 'from', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>}, 
+			{Header: 'From', accessor: 'from', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
 			{Header: 'To', accessor: 'to', Cell: props => <NavLink to={`/address/${props.value}`}>{props.value}</NavLink>},
 			{Header: 'Amount', accessor: 'amount', Cell: props => <span>{formatValue(props.value)} <AlgoIcon /></span>},
 			{Header: 'Fee', accessor: 'fee', Cell: props => <span>{formatValue(props.value)} <AlgoIcon /></span>}


### PR DESCRIPTION
I'm making this PR as a part of **grow-algorand**, particularly [this issue](https://github.com/algorandfoundation/grow-algorand/issues/9).

The following has been done:
1. Added indexer v2 support in the configuration (`src/global.sample.js` and `src/global.sandbox.js`).
2. Migrated all the APIs from algod v1 to v2.
3. Updated `service/sync/initSync.js` to insert views into CouchDB instead of developers needing to manually do them using the GUI.
4. Created a `Dockerfile` to run AlgoSearch provided `src/global.js` is supplied.
5. Created a `docker-compose.yml` to run AlgoSearch and CouchDB provided `src/global.js` is supplied.
6. Added a health check endpoint
7. Updated `README.md` to explain all the available steps to run AlgoSearch (Native, Docker, Docker Compose). I highly recommend looking at this to check all my implementations.

For the algod API migration, there are a couple of concerns and I need directions for them though:

1. Proposer is gone from the API (look at [here](https://forum.algorand.org/t/finding-blocks-proposer-with-new-api-v2/1778)), I need help to proceed. 
2. The previous block hash I presenting should be correct, but I'm not sure about current block hash, because I'm using `genesis block hash` for it. Please check and make sure I'm doing this correctly.
3. On the transaction page, there is a `note` field that originally shows both the byte string and the decoded string. In API v2 only note is shown, please check if I'm listing it correctly.